### PR TITLE
chore(infra): rename home-lab cluster + move runners to polaris

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,8 +36,6 @@ jobs:
       build_args: |
         NEXT_PUBLIC_GA_MEASUREMENT_ID=G-1GSBD62ZVM
       push: false
-      repository_path: '/home/lab/portfolio'
-      pull_code: true
     secrets:
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
@@ -75,8 +73,6 @@ jobs:
       build_args: |
         NEXT_PUBLIC_GA_MEASUREMENT_ID=G-1GSBD62ZVM
       push: true
-      repository_path: '/home/lab/portfolio'
-      pull_code: false
     secrets:
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
       build_command: 'npm run build'
       run_build: true
       allure_results_dir: 'reports/allure'
-      allure_server_url: 'http://home-lab:5050'
+      allure_server_url: 'http://astro-antares:5050'
       allure_project_id: 'portfolio-unit'
       allure_launch_name: 'Portfolio Unit Tests'
     secrets:
@@ -86,7 +86,7 @@ jobs:
   kick-off-e2e:
     name: Kick off E2E tests
     needs: tests
-    runs-on: self-hosted
+    runs-on: polaris
     steps:
       - name: Trigger E2E workflow
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ jobs:
     name: Run E2E tests (Playwright + Allure)
     uses: 922-Studio/workflows/.github/workflows/frontend-e2e.yml@main
     with:
-      runner: '["self-hosted", "e2e"]'
+      runner: '["polaris", "e2e"]'
       node_version: '22'
       build_command: 'npm run build'
       browsers: 'chromium'

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ cancel-previous → version → build (parallel: tests) → push-prod → kick-o
 | `build` | Builds Docker image on runner (no push) |
 | `tests` | Runs Vitest with coverage, reports to Allure server |
 | `push-prod` | Pushes image to private registry with `prod` and `prod-vX.Y.Z` tags |
-| `kick-off-e2e` | Triggers the `e2e.yml` workflow on the self-hosted runner |
+| `kick-off-e2e` | Triggers the `e2e.yml` workflow on the polaris runner |
 | `notify-success` | Discord notification on success |
 | `notify-failure` | Discord notification + GitHub issue on failure |
 


### PR DESCRIPTION
## Summary

- Replace `home-lab` hostname with `astro-antares` in workflow Allure server URL
- Migrate `runs-on: self-hosted` → `runs-on: polaris` in `deploy.yml`
- Migrate `["self-hosted", "e2e"]` → `["polaris", "e2e"]` in `e2e.yml`
- Update README runner description to match

## Test plan
- [ ] Confirm CI workflows pick up the new runner label `polaris`
- [ ] Verify Allure reports post to `astro-antares:5050` after next deploy