### PR TITLE
fix(ci): replace gh CLI with github-script for E2E trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,15 +82,19 @@ jobs:
   kick-off-e2e:
     name: Kick off E2E tests
     needs: tests
-    runs-on: polaris
+    runs-on: ubuntu-latest
     steps:
       - name: Trigger E2E workflow
-        run: |
-          gh workflow run e2e.yml \
-            --repo ${{ github.repository }} \
-            --ref ${{ github.ref_name }}
-        env:
-          GH_TOKEN: ${{ secrets.PAT_GITHUB }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_GITHUB }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'e2e.yml',
+              ref: context.ref,
+            });
 
   # ────────────────────────────────────────────────────────────────────────────
   create-issue:


### PR DESCRIPTION
## Summary

- The polaris runner (`actions-runner-2`) does not have `gh` CLI installed, causing the `kick-off-e2e` job to fail with `gh: command not found` (exit code 127)
- All other jobs (version, build, tests, push-prod) are passing green
- Replaces the shell `gh workflow run` call with `actions/github-script@v7` using the built-in Octokit API client — no host toolchain dependency
- Moves the job to `ubuntu-latest` (GitHub-hosted) since it only needs API access, not self-hosted runner capabilities

## Test plan

- [ ] PR CI passes (the kick-off-e2e job runs on ubuntu-latest with github-script)
- [ ] After merge, deploy run goes fully green including E2E trigger
- [ ] Open CI Failure issues closed once deploy is confirmed green