### PR TITLE
fix(test): default unit-test script to single-run

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint",
     "test": "playwright test",
     "test:install": "playwright install --with-deps chromium",
-    "test:unit": "vitest",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
     "test:unit:ci": "vitest run",
     "test:coverage": "vitest run --coverage"
   },


### PR DESCRIPTION
## Problem

`"test:unit": "vitest"` runs Vitest in **watch mode** by default. Watch mode spawns a persistent worker pool; when the controlling process is killed, those workers reparent to launchd and accumulate, consuming memory over time.

## Fix

- `test:unit` → `vitest run` (single-pass, exits cleanly)
- `test:unit:watch` → `vitest` (new alias for interactive watch during local dev)
- `test:unit:ci` and `test:coverage` are unchanged (already used `vitest run`)