### PR TITLE
fix(test): pin vitest root to fix setup file resolution on all CI runners

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -11,10 +11,16 @@ export default defineConfig({
     },
   },
   test: {
+    // Pin the project root to the directory containing vitest.config.mts.
+    // Without this, Vitest's searchForWorkspaceRoot walks up to the git root
+    // (one level above on CI runners that check out into a workspace dir),
+    // causing setupFiles and other relative paths to resolve against the wrong
+    // directory. Identical fix applied to HomeUI in PR #113.
+    root: path.resolve(__dirname, '.'),
     environment: 'jsdom',
     setupFiles: process.env.ALLURE_RESULTS_DIR
-      ? ['allure-vitest/setup', './src/test/setup.ts']
-      : ['./src/test/setup.ts'],
+      ? ['allure-vitest/setup', path.resolve(__dirname, './src/test/setup.ts')]
+      : [path.resolve(__dirname, './src/test/setup.ts')],
     exclude: ['**/node_modules/**', '**/dist/**', '**/e2e/**'],
     reporters: process.env.ALLURE_RESULTS_DIR
       ? [


### PR DESCRIPTION
## Problem

All 7 unit-test suites failed on CI with:
```
Error: Failed to load url …/Portfolio/src/test/setup.ts. Does the file exist?
```

Vitest's `searchForWorkspaceRoot` climbs from the config directory up to the git root. On CI runners where the workspace checkout layout differs (e.g. `actions-runner-4`), relative `setupFiles` paths resolve against the wrong directory.

## Fix

- Add `root: path.resolve(__dirname, '.')` to the `test` block in `vitest.config.mts` — pins Vitest's root to the directory containing the config file.
- Convert all `setupFiles` entries to absolute paths via `path.resolve(__dirname, ...)`.

Identical fix to HomeUI PR #113.

## Verification

Local: `7 passed (51 tests)`, exit 0.

## Issues Closed

Closes #18, #16, #14